### PR TITLE
add logging of program name and args plus minor tweaks

### DIFF
--- a/src/ld-preload/README.md
+++ b/src/ld-preload/README.md
@@ -60,8 +60,10 @@ created PNG-file 'outputs/no.json_map.png'
 | 2 | Process ID |
 | 3 | Parent process ID |
 | 4 | Process group ID |
-| 5 | Name of the intercepted function |
-| 6+ | Arguments of the intercepted function such as the accessed `path`, the flags to open a file, the mode to open a file, etc |
+| 5 | Full path to the program being run |
+| 6 | All command line arguments to program (including program name as used on command line). Arguments are separated by `%%`. Whitespaces ('` `' and '`\t`') in arguments are replaced by `##`. |
+| 7 | Name of the intercepted function |
+| 8+ | Arguments of the intercepted function such as the accessed `path`, the flags to open a file, the mode to open a file, etc |
 
 ### Configuring log file path and name
 The log file always contains the process ID as suffix, is by default written into the directory `${HOME}/.vdi/logs/` and has the prefix/name `vdi_log.`.


### PR DESCRIPTION
Note, we have to be careful using functions that are wrapped in the `vdi_logger`. This PR uses `fopen` to obtain the command line arguments for a process via `/proc/PID/cmdline`. So, we have to obtain the actual symbol for `fopen` and then use that instead of simply using `fopen`.