### PR TITLE
add download feature for *open* calls if pathname is an URL

### DIFF
--- a/src/vdi_wrapper/Makefile
+++ b/src/vdi_wrapper/Makefile
@@ -4,7 +4,7 @@ ARCH := $(shell uname -m)
 # define the compiler and flags
 CC = gcc
 CFLAGS = -fPIC -shared -Wall -Wextra -Werror -g
-LDFLAGS = -ldl
+LDFLAGS = -ldl -lcurl
 
 # determine path to compiler set by CC
 PATH_TO_CC := $(shell command -v ${CC})


### PR DESCRIPTION
When pathname to be opened is a URL with `https`, `http` or `ftp` it downloads the resource with `libcurl` to a local file and then opens that.

Doesn't work with `tar` and `gzip`.